### PR TITLE
Add Unlearning Depth Score to 2026 papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,11 @@ As of the last commit, there are **592** papers, **18** surveys and position pap
   - Date: 2026-04
   - Venue: -
   - Code: -
+- [Measuring the Depth of LLM Unlearning via Activation Patching](https://arxiv.org/abs/2605.24614)
+  - Author(s): Jaeung Lee, Dohyun Kim, Jaemin Jo
+  - Date: 2026-05
+  - Venue: -
+  - Code: [![GitHub](https://img.shields.io/badge/GitHub-181717?style=flat&logo=github&logoColor=white)](https://github.com/gnueaj/unlearning-depth-score)
 - [Modeling LLM Unlearning as an Asymmetric Two-Task Learning Problem](https://arxiv.org/abs/2604.14808)
   - Author(s): Zeguan Xiao, Siqing Li, Yong Wang, Xuetao Wei, Jian Yang, Yun Chen, Guanhua Chen
   - Date: 2026-04


### PR DESCRIPTION
Adds our paper introducing Unlearning Depth Score (UDS), a white-box metric
that measures unlearning depth via two-stage activation patching on internal
hidden states, evaluated on TOFU forget10 across 150 unlearned Llama-3.2-1B-
Instruct models spanning 8 unlearning methods.

Paper: https://arxiv.org/abs/2605.24614
Code: https://github.com/gnueaj/unlearning-depth-score

It's the first mechanistic metric for unlearning depth, and we thought it'd be
a nice addition to this list. Thank you for maintaining such a great resource
for the unlearning community 😊

Best,
Jaeung